### PR TITLE
Restore non-cloud support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,24 @@ platforms:
   - recipe[apt]
 
 suites:
+  - name: not_cloud
+    run_list:
+      - recipe[rackspace_cloudbackup::not_cloud]
+    attributes:
+      rackspace_cloudbackup:
+        mock: true
+        backups:
+          - location: /etc
+            enabled: false
+          - location: /home
+            enabled: false
+        backups_defaults:
+          non_cloud_container: testContainer
+      rackspace:
+        datacenter: 'DFW'
+        cloud_credentials:
+          username: nobody
+          api_key:  secret
   - name: cloud
     run_list:
       - recipe[rackspace_cloudbackup::cloud]

--- a/files/default/turbolift_backup.sh
+++ b/files/default/turbolift_backup.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# turbolift_backup.sh: Wrapper around turbolift to simplify Cron calls.
+#
+# Copyright 2014 Rackspace Hosting, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# usage: Print usage to stdout
+# Arguments: NONE
+function usage {
+    echo "turbolift_backup.sh: Wrapper around turbolift to simplify Cron calls"
+    echo "USAGE: turbolift_backup.sh -u [API Username] -k [API Key] -d [Datacenter]"
+    echo -e "\t-u: Rackspace API username"
+    echo -e "\t-k: Rackspace API key"
+    echo -e "\t-d: Rackspace datacenter to back up to (DFW, IAD, ORD, etc...)"
+    echo -e "\t-c: Rackspace CloudFiles container to back up to"
+    echo -e "\t-l: Location (path) to backup"
+    echo -e "\t-D: Disable the backup"
+    echo -e "\t-s: Log to syslog"
+    echo -e "\t-v: Be verbose"
+}
+
+# print_helper: Helper function for printing output
+# ARGUMENTS:
+# $1: String to print
+# $2: Location:
+#       0: stdout
+#       1: syslog
+#       Default: stderr
+function print_helper {
+    case $2 in
+	0)
+	    echo "${1}"
+	    ;;
+	1)
+	    logger "turbolift_backup.sh: ${1}"
+	    ;;
+	*)
+	    echo "${1}" >&2
+	    ;;
+    esac
+}
+
+loglocation=0
+verbose=0
+disabled=0
+
+while getopts "k:u:d:c:l:Dsv" opt; do
+    case "${opt}" in
+	k)
+	    apikey=${OPTARG}
+	    ;;
+	u)
+	    apiuser=${OPTARG}
+	    ;;
+	d)
+	    # turbolift expects lowercase datacenter
+	    datacenter=$(echo "${OPTARG}" | tr '[:upper:]' '[:lower:]')
+	    ;;
+	c)
+	    container=${OPTARG}
+	    ;;
+	l)
+	    location=${OPTARG}
+	    ;;
+	D)
+	    disabled=1
+	    ;;
+	s)
+	    loglocation=1
+	    ;;
+	v)
+	    verbose=1
+	    ;;
+	    
+	*)
+	    usage
+	    exit 1
+	    ;;
+    esac
+done
+
+if [ $verbose -eq 1 ]; then
+    print_helper "Settings:" $loglocation
+    print_helper "   API Key:    ${apikey}"  $loglocation
+    print_helper "   API User:   ${apiuser}"  $loglocation
+    print_helper "   Datacenter: ${datacenter}"  $loglocation
+    print_helper "   Container:  ${container}"  $loglocation
+    print_helper "   Location:   ${location}"  $loglocation
+    print_helper "   Disabled:   ${disabled}"  $loglocation
+    print_helper "   Log location: ${loglocation}"  $loglocation
+fi
+
+# Verify mandatory options are set
+if [ -z "${apikey}" ]; then
+    print_helper "ERROR: API Key not set" $loglocation
+    exit 1
+fi
+
+if [ -z "${apiuser}" ]; then
+    print_helper "ERROR: API Username not set" $loglocation
+    exit 1
+fi
+
+if [ -z "${datacenter}" ]; then
+    print_helper "ERROR: Datacenter not set" $loglocation
+    exit 1
+fi
+
+if [ -z "${container}" ]; then
+    print_helper "ERROR: Container not set" $loglocation
+    exit 1
+fi
+
+if [ -z "${location}" ]; then
+    print_helper "ERROR: Location not set" $loglocation
+    exit 1
+fi
+
+if [ $disabled -eq 1 ]; then
+    print_helper "Notice: Backup for ${location} disabled" $loglocation
+    exit 0
+fi
+
+tarlocation=$(echo "$location" | sed -e 's|/|___|g')
+time=$(date +%Y-%m-%d_%H:%M:%S)
+tarname="$(hostname -f)-${time}-${tarlocation}"
+turbolift --quiet --os-rax-auth $datacenter -u $apiuser -a $apikey archive -s $location -c $container --verify --tar-name $tarname
+retval=$?
+
+if [ $retval -ne 0 ]; then
+    print_helper "WARNING: Turbolift returned code ${retval} for location ${location}" $loglocation
+    exit 1
+else
+    if [ $verbose -eq 1 ]; then
+	print_helper "NOTICE: Turbolift returned success code ${retval} for location ${location}, backup file \"${tarname}\"" $loglocation
+    fi
+    exit 0
+fi

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,8 +10,11 @@ if defined?(node['cloud']['provider'])
   if node['cloud']['provider'] == 'rackspace'
     include_recipe 'rackspace_cloudbackup::cloud'
   else
-    fail "ERROR: backups currently unsupported on #{node['cloud']['provider']} cloud servers"
+    include_recipe 'rackspace_cloudbackup::not_cloud'
   end
 else
-  fail "ERROR: backups currently unsupported on non-cloud servers"
+  log 'message' do
+    message "Could not find the node['cloud']['provider'] attribute!"
+    level :warn
+  end
 end

--- a/recipes/not_cloud.rb
+++ b/recipes/not_cloud.rb
@@ -1,0 +1,100 @@
+#
+# Cookbook Name:: rackspace-cloud-backup
+# Recipe:: default
+#
+# Copyright 2013, Rackspace US, Inc.
+#
+# Apache 2.0
+#
+# set up repos
+
+case node[:platform]
+when 'redhat', 'centos'
+  yum_repository 'rackops-repo' do
+    description 'Rackspace rackops repo'
+    url 'http://repo.rackops.org/rpm/'
+    gpgkey 'http://repo.rackops.org/rackops-signing-key.asc'
+  end
+when 'ubuntu', 'debian'
+  case node['lsb'][:codename]
+  when 'precise'
+    apt_repository 'rackops-repo' do
+      uri 'http://repo.rackops.org/apt/ubuntu'
+      distribution 'precise'
+      components ['main']
+      key 'http://repo.rackops.org/rackops-signing-key.asc'
+      action :add
+    end
+  when 'wheezy'
+    apt_repository 'rackops-repo' do
+      uri 'http://repo.rackops.org/apt/debian'
+      distribution 'wheezy'
+      components ['main']
+      key 'http://repo.rackops.org/rackops-signing-key.asc'
+      action :add
+    end
+  end
+end
+
+# install turbolift
+package 'python-turbolift' do
+  action :upgrade
+end
+
+# Install the helper wrapper
+['turbolift_backup.sh'].each do |script|
+  cookbook_file "/usr/local/bin/#{script}" do
+    source script
+    mode 00755
+    owner 'root'
+    group 'root'
+  end
+end
+
+# Ensure mandatory options are set
+if node['rackspace']['cloud_credentials']['username'].nil? || node['rackspace']['cloud_credentials']['api_key'].nil?
+  fail 'ERROR: Cloud credentials unset'
+end
+
+fail 'ERROR: datacenter not set' if node['rackspace']['datacenter'].nil?
+
+node['rackspace_cloudbackup']['backups'].each do |node_job|
+  job = node_job.dup # Obtain a copy that's not in the node attributes so we can tinker in it
+
+  if job['label'].nil?
+    # NOTE: This format intentionally matches earlier revisions to avoid creating duplicate backups
+    job['label'] = "Backup for #{node['ipaddress']}, backing up #{job['location']}"
+  end
+
+  if job['non_cloud'].nil?
+    job['non_cloud'] = {}
+  end
+
+  if job['enabled'].nil?
+    job['enabled'] = true
+  end
+
+  container = job['non_cloud']['container'].nil? ? node['rackspace_cloudbackup']['backups_defaults']['non_cloud_container'] : job['non_cloud']['container']
+  fail "ERROR: Target backup container not set for location \"#{job['location']}\"" if container.nil?
+
+  # Build the command
+  # Broken up to keep lines short and to enable flag toggles
+  command_str = '/usr/local/bin/turbolift_backup.sh -s'
+  command_str += " -u #{node['rackspace']['cloud_credentials']['username']}"
+  command_str += " -k #{node['rackspace']['cloud_credentials']['api_key']}"
+  command_str += " -d #{node['rackspace']['datacenter']}"
+  command_str += " -c #{container}"
+  command_str += " -l \"#{job['location']}\""
+
+  unless job['enabled']
+    # Set the disabled bit
+    # This is the primary value of the wrapper script, the job will still exist but turbolift won't run.
+    command_str += ' -D'
+  end
+
+  # Shared defininition from definitions/cron_wrapper.rb
+  cloud_backup_cron_configurator "#{job['label']} cron_configurator" do
+    job job
+    command command_str
+  end
+end

--- a/spec/unit/recipes/not_cloud_spec.rb
+++ b/spec/unit/recipes/not_cloud_spec.rb
@@ -1,0 +1,100 @@
+#
+# Cookbook Name:: rackspace_cloudbackup
+#
+# Copyright 2014, Rackspace, US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../../supported_platforms.rb'
+
+# Define the unique helper module for this test suite.
+module NotCloudSpecHelpers
+  def initialize_tests
+    # This is required here as ChefSpec interferes with WebMocks, breaking tests
+    # rspec does not fully reinitialize the global namespace, so anything declared outside of tests
+    # shared between all tests.
+    require 'chefspec_helper'
+  end
+  module_function :initialize_tests
+
+  def test_backup_data
+    return [
+            { 'label' => 'test /tmp backup',      'location' => '/tmp/' },
+            { 'label' => 'test /dev/null backup', 'location' => '/dev/null' }
+           ]
+  end
+  module_function :test_backup_data
+end
+
+describe 'rackspace_cloudbackup::cloud' do
+  # TODO: Determine if this causes conflicts at this level.
+  NotCloudSpecHelpers.initialize_tests
+
+  rackspace_cloudbackup_test_platforms.each do |platform, versions|
+    describe "on #{platform}" do
+      versions.each do |version|
+        describe version do
+          let(:chef_run) do
+            ChefSpec::Runner.new(platform: platform.to_s,
+                                 version: version.to_s,
+                                 step_into: ['rackspace_cloudmonitoring_agent_token']
+                                 ) do |node|
+              node.set['rackspace_cloudbackup']['mock'] = true
+              node.set['rackspace']['cloud_credentials']['username'] = 'IfThisHitsTheApiSomethingIsBusted'
+              node.set['rackspace']['cloud_credentials']['api_key']  = 'SuchFakePassword.VeryMock.Wow.'
+              node.set['rackspace']['datacenter']                    = 'DFW'
+              node.set['rackspace_cloudbackup']['backups_defaults']['non_cloud_container'] = 'testContainer'
+            end
+          end
+
+          before :each do
+            chef_run.node.set['rackspace_cloudbackup']['backups'] = NotCloudSpecHelpers.test_backup_data
+            chef_run.converge('rackspace_cloudbackup::not_cloud')
+          end
+
+          # TODO: Test failure on missing settings
+
+          it 'Installs the rackops-repo repository' do
+            case platform.to_s
+            when 'redhat', 'centos'
+              expect(chef_run).to create_yum_repository('rackops-repo')
+            when 'ubuntu', 'debian'
+              expect(chef_run).to add_apt_repository('rackops-repo')
+            else
+              fail "ERROR: Unknown platform #{platform}"
+            end
+          end
+
+          it 'installs python-argparse' do
+            expect(chef_run).to upgrade_package 'python-turbolift'
+          end
+
+          it 'installs turbolift_backup.sh' do
+            expect(chef_run).to render_file('/usr/local/bin/turbolift_backup.sh')
+          end
+
+          NotCloudSpecHelpers.test_backup_data.each do |job|
+            describe "test backup of '#{job['location']}'" do
+              # Test the behavior, not the implementation.  Don't worry that it's a definition
+              # This is shared with cloud, and can be deduped.
+              it 'configures the cron job' do
+                # TODO: Also spartan
+                expect(chef_run).to create_cron("'#{job['label']}' cronjob")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/integration/not_cloud/serverspec/non_cloud_spec.rb
+++ b/test/integration/not_cloud/serverspec/non_cloud_spec.rb
@@ -1,0 +1,44 @@
+# non_cloud_spec.rb: serverspec file for testing the non_cloud recipe
+
+require 'spec_helper'
+
+# Define the unique helper module for this test suite.
+module NonCloudSpecHelpers
+  def crontab_path
+    case os[:family].downcase
+    when 'redhat', 'centos'
+      return '/var/spool/cron/root'
+    when 'ubuntu', 'debian'
+      return '/var/spool/cron/crontabs/root'
+    else
+      fail "Unknown OS \"#{os[:family]}\""
+    end
+  end
+  module_function :crontab_path
+end
+
+describe 'Non-cloud server' do
+  describe command('/usr/bin/turbolift --help') do
+    # If there are dependency errors or other turbolift errors this won't return 0
+    it { should return_exit_status 0 }
+  end
+
+  describe file('/usr/local/bin/turbolift_backup.sh') do
+    it { should be_file }
+    it { should be_executable }
+    it { should be_owned_by 'root' }
+    it { should be_readable.by('others') }
+  end
+
+  describe file(NonCloudSpecHelpers.crontab_path) do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_mode 600 } # As it contins the API key
+    
+    # Check the jorbs
+    # These settings come through from the .kitchen.yml file
+    it { should contain '/usr/local/bin/turbolift_backup.sh -s -u nobody -k secret -d DFW -c testContainer -l "/etc" -D' }
+    it { should contain '/usr/local/bin/turbolift_backup.sh -s -u nobody -k secret -d DFW -c testContainer -l "/home" -D' }
+  end
+end
+  

--- a/test/integration/not_cloud/serverspec/spec_helper.rb
+++ b/test/integration/not_cloud/serverspec/spec_helper.rb
@@ -1,0 +1,11 @@
+require 'serverspec'
+require 'pathname'
+
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS
+
+RSpec.configure do |c|
+  c.before :all do
+    c.os = backend(Serverspec::Commands::Base).check_os
+  end
+end


### PR DESCRIPTION
During the v1.0.0 refactor non-cloud support was removed to keep the scope to something resonable.  This is the code that was removed, which needs to be completed before it can be re-added.  It currently fails tests as the turbolift package doesn't install all the python modules required, requiring modules to be pip installed before turbolift will work.  Having Chef pip install modules seems like a risk due to installing code from outside the package manager and potential issues with customer Python modules.
