### PR TITLE
Update rest-client require so happens at runtime

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+# Rubocop,  we're buddies and all,  but we're going to have to disagree on the following -
+
 # Disable requirement of "encoding" headers on files
 Encoding:
   Enabled: false
@@ -24,10 +26,19 @@ IfUnlessModifier:
 CyclomaticComplexity:
   Max: 10
 
-# Raise allowed parameter count to 8, 5 is a bit low.
-ParameterLists:
-  Max: 8
-
-# 123_456 doesn't add value IMO.
-NumericLiterals:
+# Disable Single Space before first arg
+SingleSpaceBeforeFirstArg:
   Enabled: false
+
+# Don't force a word array unless 5 elements
+WordArray:
+  MinSize: 5
+
+# Don't complain about unused block args
+UnusedBlockArgument:
+  Enabled: false
+
+AllCops:
+  Include:
+    - '**/metadata.rb'
+    - '**/*.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of rackspace-cloud-backup.
 
+## 1.0.1
+* Move rest-client requires into each method call, so cookbook can be loaded and afterwards install gem requirements (otherwise upgrades are impossible)
+
 ## 1.0.0:
 * Change namespace to rackspace_cloudbackup
 * Provide a parameterized configuration hash

--- a/libraries/RcbuApiWrapper.rb
+++ b/libraries/RcbuApiWrapper.rb
@@ -16,7 +16,6 @@
 #
 
 require 'json'
-require 'rest_client'
 
 module Opscode
   module Rackspace
@@ -27,6 +26,7 @@ module Opscode
         attr_accessor :token, :rcbu_api_url, :agent_id, :configurations, :identity_api_url
 
         def initialize(api_username, api_key, region, agent_id, identity_api_url = 'https://identity.api.rackspacecloud.com/v2.0/tokens')
+          require 'rest_client'
           @agent_id = agent_id
           @identity_api_url = identity_api_url
 
@@ -61,6 +61,7 @@ module Opscode
         end
 
         def lookup_configurations
+          require 'rest_client'
           response = RestClient.get("#{@rcbu_api_url}/backup-configuration/system/#{@agent_id}",
                                     'X-Auth-Token' => @token, 'Accept' => :json)
           if response.code != 200
@@ -83,6 +84,7 @@ module Opscode
         end
 
         def create_config(config)
+          require 'rest_client'
           response = RestClient.post("#{@rcbu_api_url}/backup-configuration/",
                                      config.to_json,
                                      'Content-Type' => :json, 'X-Auth-Token' => @token)
@@ -93,6 +95,7 @@ module Opscode
         end
 
         def update_config(config_id, config)
+          require 'rest_client'
           response = RestClient.put("#{@rcbu_api_url}/backup-configuration/#{config_id}",
                                     config.to_json,
                                     'Content-Type' => :json, 'X-Auth-Token' => @token)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache 2.0'
 description      'Installs/Configures rackspace-cloud-backup'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '1.0.0'
+version          '1.0.1'
 
 recipe           'rackspace-cloud-backup', 'Installs and registers cloud backup'
 


### PR DESCRIPTION
Require rest-client at runtime instead of load time, so chef can install the `rest-client` gem after loading all ruby classes, but before running any. RE: https://github.com/rackops/rackops_rolebook/issues/43.
