### PR TITLE
Declare/install dependency on rest-client

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,6 +6,12 @@
 #
 # Apache 2.0
 #
+
+# ensure rest-client gem is available
+chef_gem 'rest-client' do
+  action :nothing
+end.run_action(:install)
+
 if defined?(node['cloud']['provider'])
   if node['cloud']['provider'] == 'rackspace'
     include_recipe 'rackspace_cloudbackup::cloud'


### PR DESCRIPTION
We should install gems we require. rest-client should be installed by the default recipe.