### PR TITLE
Relax apt cookbook dependency to allow it to work with newer apt versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ recipe           'default', 'Installs and registers cloud backup'
 recipe           'cloud', 'Installs and registers cloud backup, bypasses cloud provider check'
 recipe           'cloud_agent', 'Registers the node as a cloud backup system'
 
-depends 'apt', '~> 2.0'
+depends 'apt', '>= 2.0'
 depends 'build-essential'
 depends 'yum', '~> 3.0'
 depends 'yum-epel', '~> 0.5.3'


### PR DESCRIPTION
The latest version is v6.1.4 but we had been locked to a v2.X version, which is quite old.