### PR TITLE
Fix modifying frozen region string for Chef 13 compatibility

### DIFF
--- a/libraries/RcbuApiWrapper.rb
+++ b/libraries/RcbuApiWrapper.rb
@@ -36,7 +36,7 @@ module Opscode
           backup_catalog = identity['access']['serviceCatalog'].find { |c| c['name'] == 'cloudBackup' }
           fail 'Opscode::Rackspace::CloudBackup::RcbuAPIWrapper.initialize: Unable to locate cloudBackup service catalog' if backup_catalog.nil?
 
-          region.upcase!
+          region = region.upcase
           backup_catalog_region = backup_catalog['endpoints'].find { |e| e['region'] == region }
           if backup_catalog_region.nil?
             fail "Opscode::Rackspace::CloudBackup::RcbuAPIWrapper.initialize: Unable to locate CloudBackup details from service catalog for region #{region}"

--- a/recipes/cloud.rb
+++ b/recipes/cloud.rb
@@ -122,7 +122,7 @@ template '/etc/driveclient/run_backup.conf.yaml' do
   variables(
     api_username:  node['rackspace']['cloud_credentials']['username'],
     api_key:       node['rackspace']['cloud_credentials']['api_key'],
-    api_region:    node['rackspace']['datacenter'],
+    api_region:    node['rackspace']['datacenter'].upcase,
     mock:          node['rackspace_cloudbackup']['mock'],
     backup_config: template_data
   )


### PR DESCRIPTION
After upgrading from chef v12.22 to v13.10, I saw the following error:

```
================================================================================
Error executing action `create` on resource 'rackspace_cloudbackup_configure_cloud_backup[Backup for App, backing up /applications/my-app/shared/public/uploads]'
================================================================================

RuntimeError
------------
can't modify frozen String

Cookbook Trace:
---------------
/home/cgunther/chef-solo/local-mode-cache/cache/cookbooks/rackspace_cloudbackup/libraries/RcbuApiWrapper.rb:39:in `upcase!'
/home/cgunther/chef-solo/local-mode-cache/cache/cookbooks/rackspace_cloudbackup/libraries/RcbuApiWrapper.rb:39:in `initialize'
/home/cgunther/chef-solo/local-mode-cache/cache/cookbooks/rackspace_cloudbackup/libraries/RcbuBackupWrapper.rb:114:in `new'
/home/cgunther/chef-solo/local-mode-cache/cache/cookbooks/rackspace_cloudbackup/libraries/RcbuBackupWrapper.rb:114:in `_get_api_obj'
/home/cgunther/chef-solo/local-mode-cache/cache/cookbooks/rackspace_cloudbackup/libraries/RcbuBackupWrapper.rb:125:in `_get_backup_obj'
/home/cgunther/chef-solo/local-mode-cache/cache/cookbooks/rackspace_cloudbackup/libraries/RcbuBackupWrapper.rb:41:in `initialize'
/home/cgunther/chef-solo/local-mode-cache/cache/cookbooks/rackspace_cloudbackup/libraries/configure_cloud_backup_hwrp.rb:160:in `new'
/home/cgunther/chef-solo/local-mode-cache/cache/cookbooks/rackspace_cloudbackup/libraries/configure_cloud_backup_hwrp.rb:160:in `load_current_resource'

Resource Declaration:
---------------------
# In /home/cgunther/chef-solo/local-mode-cache/cache/cookbooks/rackspace_cloudbackup/recipes/cloud.rb

 83:   rackspace_cloudbackup_configure_cloud_backup job['label'] do
 84:     rackspace_username   node['rackspace']['cloud_credentials']['username']
 85:     rackspace_api_key    node['rackspace']['cloud_credentials']['api_key']
 86:     rackspace_api_region node['rackspace']['datacenter']
 87:     inclusions           [job['location']]
 88: 
 89:     version_retention    job['cloud']['version_retention'] || node['rackspace_cloudbackup']['backups_defaults']['cloud_version_retention']
 90:     notify_recipients    job['cloud']['notify_email'] || node['rackspace_cloudbackup']['backups_defaults']['cloud_notify_email']
 91:     is_active            job['enabled']
 92: 
 93:     # Backups configured with this module are triggered by cron for consistency with non-RS cloud
 94:     frequency            'Manually'
 95: 
 96:     # For various tests
 97:     mock                 node['rackspace_cloudbackup']['mock']
 98:     action :create
 99:   end
100: 

Compiled Resource:
------------------
# Declared in /home/cgunther/chef-solo/local-mode-cache/cache/cookbooks/rackspace_cloudbackup/recipes/cloud.rb:83:in `block in from_file'

rackspace_cloudbackup_configure_cloud_backup("Backup for App, backing up /applications/my-app/shared/public/uploads") do
  provider Chef::Provider::RackspaceCloudbackupConfigureCloudBackup
  action [:create]
  default_guard_interpreter :default
  label "Backup for App, backing up /applications/my-app/shared/public/uploads"
  is_active true
  missed_backup_action_id 1
  notify_failure true
  time_zone_id "UTC"
  rcbu_bootstrap_file "/etc/driveclient/bootstrap.json"
  declared_type :rackspace_cloudbackup_configure_cloud_backup
  cookbook_name "rackspace_cloudbackup"
  recipe_name "cloud"
  rackspace_username "****"
  rackspace_api_key "****"
  rackspace_api_region "iad"
  inclusions ["/applications/my-app/shared/public/uploads"]
  version_retention 30
  notify_recipients "****"
  frequency "Manually"
end

System Info:
------------
chef_version=13.10.0
platform=ubuntu
platform_version=16.04
ruby=ruby 2.4.4p296 (2018-03-28 revision 63013) [x86_64-linux]
program_name=chef-solo worker: ppid=26596;start=14:15:16;
executable=/opt/chef/bin/chef-solo
```

I believe the cause is something about resources not being cloned anymore in Chef 13, but I'm not sure what's causing the region, which comes from the node's attributes to be frozen.

Removing the in-place upcasing fixed the issue, but then I noticed since my region is defined in lowercase in attribute, the run_backup.conf.yaml file now showed the region in lowercase as it seems this was affected by the in-place upcasing, so I'm explicitly upcasing the region before passing to the template.