### PR TITLE
Replace node.set with node.override

### DIFF
--- a/recipes/cloud.rb
+++ b/recipes/cloud.rb
@@ -17,7 +17,7 @@
 #
 
 # ensure rest-client gem is available
-node.set['build-essential']['compile_time'] = true
+node.override['build-essential']['compile_time'] = true
 include_recipe 'build-essential'
 chef_gem 'rest-client' do
   action :nothing


### PR DESCRIPTION
node.set was deprecated then removed in Chef 14.

They recommend replacing it with either node.normal or node.override, but node.override seemed appropriate here as we're trying to force a value.